### PR TITLE
Fix code scanning alert no. 4: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/fastrpc_cap.c
+++ b/src/fastrpc_cap.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 
 #define FARF_ERROR 1
 
@@ -58,11 +59,12 @@ static inline uint32_t fastrpc_check_if_dsp_present_rproc(uint32_t domain) {
 	while (1) {
 		memset(buffer, 0, BUF_SIZE);
 		snprintf(buffer, BUF_SIZE, "%s%d", dir_base_path, dir_index);
-		if (stat(buffer, &dir_stat) == -1) {
+		std_strlcat(buffer, "/name", BUF_SIZE);
+		int fd = open(buffer, O_RDONLY);
+		if (fd == -1) {
 			break;
 		}
-		std_strlcat(buffer, "/name", BUF_SIZE);
-		FILE *file = fopen(buffer, "r");
+		FILE *file = fdopen(fd, "r");
 		if (file != NULL) {
 			memset(buffer, 0, BUF_SIZE);
 			if (fgets(buffer, BUF_SIZE, file) != NULL) {
@@ -75,6 +77,7 @@ static inline uint32_t fastrpc_check_if_dsp_present_rproc(uint32_t domain) {
 			}
 			fclose(file);
 		}
+		close(fd);
 		dir_index++;
 	}
 bail :


### PR DESCRIPTION
Fixes [https://github.com/quic-mtharu/fastrpc/security/code-scanning/4](https://github.com/quic-mtharu/fastrpc/security/code-scanning/4)

To fix the TOCTOU race condition, we should use file descriptors directly instead of relying on `stat` and `fopen` separately. We can use the `open` function to obtain a file descriptor and then use `fdopen` to convert the file descriptor to a `FILE*` stream. This ensures that the file we check is the same file we open.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
