### PR TITLE
Fix code scanning alert no. 1: Signed overflow check

### DIFF
--- a/src/apps_std_imp.c
+++ b/src/apps_std_imp.c
@@ -40,6 +40,7 @@
 #include "rpcmem_internal.h"
 #include "verify.h"
 #include <dirent.h>
+#include <limits.h>
 #include <dlfcn.h>
 #include <errno.h>
 #include <inttypes.h>
@@ -720,7 +721,7 @@ __QAIC_IMPL(apps_std_fseek)(apps_std_FILE sin, int offset,
       sinfo->u.binfo.pos += offset;
       break;
     case APPS_STD_SEEK_END:
-      VERIFYC(offset + sinfo->u.binfo.flen <= sinfo->u.binfo.flen, AEE_EFILE);
+      VERIFYC(offset <= INT_MAX - sinfo->u.binfo.flen, AEE_EFILE);
       sinfo->u.binfo.pos += offset + sinfo->u.binfo.flen;
       break;
     }


### PR DESCRIPTION
Fixes [https://github.com/quic-mtharu/fastrpc/security/code-scanning/1](https://github.com/quic-mtharu/fastrpc/security/code-scanning/1)

Ensure signed overflow using below conditions.

1. Include the `limits.h` header to access `INT_MAX`.
2. Modify the condition to check if `offset` is greater than `INT_MAX - sinfo->u.binfo.flen`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
