### PR TITLE
Fix code scanning alert no. 3: Too few arguments to formatting function

### DIFF
--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -236,7 +236,7 @@ static void listener(struct listener *me) {
         result = AEE_EBADPARM;
         FARF(RUNTIME_RPC_HIGH,
              "adsp_listener_invoke_get_in_bufs2 failed, size is invalid req %d "
-             "inBufsLen %d result %d %x",
+             "inBufsLen %d result %d",
              req, inBufsLen, result);
         goto invoke;
       }


### PR DESCRIPTION
Fixes [https://github.com/quic-mtharu/fastrpc/security/code-scanning/3](https://github.com/quic-mtharu/fastrpc/security/code-scanning/3)

To fix the problem, we need to ensure that the number of arguments provided to the `FARF` macro matches the number of placeholders in the format string. In this case, the format string expects four arguments, but only three are provided. We need to either update the format string to expect three arguments or provide an additional argument to match the format string.

The best way to fix this without changing existing functionality is to update the format string to match the three provided arguments. This involves editing the `FARF` call on line 237 to remove the extra placeholder.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
