### PR TITLE
Fix code scanning alert no. 1: Signed overflow check

### DIFF
--- a/src/apps_std_imp.c
+++ b/src/apps_std_imp.c
@@ -40,6 +40,7 @@
 #include "rpcmem_internal.h"
 #include "verify.h"
 #include <dirent.h>
+#include <limits.h>
 #include <dlfcn.h>
 #include <errno.h>
 #include <inttypes.h>
@@ -720,7 +721,7 @@ __QAIC_IMPL(apps_std_fseek)(apps_std_FILE sin, int offset,
       sinfo->u.binfo.pos += offset;
       break;
     case APPS_STD_SEEK_END:
-      VERIFYC(offset + sinfo->u.binfo.flen <= sinfo->u.binfo.flen, AEE_EFILE);
+      VERIFYC(offset <= INT_MAX - sinfo->u.binfo.flen, AEE_EFILE);
       sinfo->u.binfo.pos += offset + sinfo->u.binfo.flen;
       break;
     }


### PR DESCRIPTION
Signed overflow check:
Testing for signed overflow may produce undefined results. Issue : When checking for integer overflow, you may often write tests like a + b < a. This works fine if a or b are unsigned integers, since any overflow in the addition will cause the value to simply "wrap around." However, using signed integers is problematic because signed overflow has undefined behavior according to the C and C++ standards. If the addition overflows and has an undefined result, the comparison will likewise be undefined; it may produce an unintended result, or may be deleted entirely by an optimizing compiler. Fix: ensure that the addition will not overflow.
1. Include the limits.h header to access INT_MAX.
2. Modify the condition to check if offset is greater than INT_MAX - sinfo->u.binfo.flen.