### PR TITLE
Fix code scanning alert no. 2: Too few arguments to formatting function

### DIFF
--- a/src/fastrpc_pm.c
+++ b/src/fastrpc_pm.c
@@ -209,7 +209,7 @@ int fastrpc_wake_lock_deinit() {
   pthread_mutex_unlock(&wakelock.wmut);
 
   if (nErr)
-    FARF(ERROR, "Error 0x%x (%d): %s failed (errno %s)\n", nErr, __func__,
+    FARF(ERROR, "Error 0x%x (%d): %s failed (errno %s)\n", nErr, nErr, __func__,
          strerror(errno));
   else
     FARF(ALWAYS, "%s done", __func__);


### PR DESCRIPTION
Error: Too few arguments to formatting function HAP_debug_v2
Fix: add the missing argument to the FARF call on line 212. The missing argument should be the return value ret